### PR TITLE
Proper registry value names

### DIFF
--- a/common.h
+++ b/common.h
@@ -3,10 +3,10 @@
 using Id = unsigned int;
 static Id running_id = 0;
 
-class Empty {};
+class Empty { };
 template <typename Base> class Identifiable : public Base {
 public:
-	Identifiable() : m_id(running_id++) {}
+	Identifiable() : m_id(running_id++) { }
 
 	Id id() const {
 		return m_id;
@@ -16,10 +16,11 @@ private:
 	const Id m_id;
 };
 
-using Color = std::tuple<BYTE, BYTE, BYTE, BYTE>;
+using Color = std::tuple<unsigned char, unsigned char, unsigned char, unsigned char>;
 enum Channel {
 	RED = 0,
 	GREEN = 1,
 	BLUE = 2,
 	ALPHA = 3
 };
+

--- a/common.h
+++ b/common.h
@@ -1,0 +1,25 @@
+#pragma once
+
+using Id = unsigned int;
+static Id running_id = 0;
+
+class Empty {};
+template <typename Base> class Identifiable : public Base {
+public:
+	Identifiable() : m_id(running_id++) {}
+
+	Id id() const {
+		return m_id;
+	}
+
+private:
+	const Id m_id;
+};
+
+using Color = std::tuple<BYTE, BYTE, BYTE, BYTE>;
+enum Channel {
+	RED = 0,
+	GREEN = 1,
+	BLUE = 2,
+	ALPHA = 3
+};

--- a/config.cpp
+++ b/config.cpp
@@ -28,29 +28,29 @@ Registry::Registry()
 Config Registry::get_config() {
 	std::vector<std::pair<ConfigOption, float>> keys;
 
-	const std::wstring migrated_registry_name = L"MigratedRegistry";
-	bool migrated_registry = (bool) ((int) get(migrated_registry_name.c_str(), 0.0f));
+	const std::wstring is_registry_migrated_name = L"IsRegistryMigrated";
+	bool is_registry_migrated = get(is_registry_migrated_name, 0.0f) != 0.0f;
 
 	for (int i = _CONFIG_OPTIONS_START + 1; i < _CONFIG_OPTIONS_END; i++) {
 		ConfigOption opt = (ConfigOption) i;
-		if (migrated_registry) {
-			keys.push_back(std::make_pair(opt, get(config_names.at(opt).c_str(), cfg_defaults.at(opt))));
+		if (is_registry_migrated) {
+			keys.push_back(std::make_pair(opt, get(config_names.at(opt), cfg_defaults.at(opt))));
 		} else {
-			std::pair<ConfigOption, float> key = std::make_pair(opt, get(std::to_wstring(opt).c_str(), cfg_defaults.at(opt)));
-			write(config_names.at(opt).c_str(), key.second);
-			remove(std::to_wstring(opt).c_str());
+			std::pair<ConfigOption, float> key = std::make_pair(opt, get(std::to_wstring(opt), cfg_defaults.at(opt)));
+			write(config_names.at(opt), key.second);
+			remove(std::to_wstring(opt));
 			keys.push_back(key);
 		}
 	}
 
-	if (!migrated_registry) {
-		write(migrated_registry_name.c_str(), 1.0f);
+	if (!is_registry_migrated) {
+		write(is_registry_migrated_name, 1.0f);
 	}
 
 	return Config(keys.begin(), keys.end());
 }
 
-float Registry::get(LPCWSTR opt, float default_) {
+float Registry::get(const std::wstring &opt, float default_) {
 	wchar_t result[1 << 6] {};
 	DWORD result_type;
 	DWORD result_size = 1 << 6;
@@ -58,7 +58,7 @@ float Registry::get(LPCWSTR opt, float default_) {
 	LSTATUS status = RegGetValue(
 		m_reg_key,
 		NULL,
-		opt,
+		opt.c_str(),
 		RRF_RT_REG_SZ,
 		&result_type,
 		result,
@@ -72,10 +72,10 @@ float Registry::get(LPCWSTR opt, float default_) {
 	return std::stof(result);
 }
 
-void Registry::write(LPCWSTR opt, float value) {
+void Registry::write(const std::wstring &opt, float value) {
 	RegSetValueEx(
 		m_reg_key,
-		opt,
+		opt.c_str(),
 		0,
 		REG_SZ,
 		(BYTE *) std::to_wstring(value).c_str(),
@@ -83,9 +83,9 @@ void Registry::write(LPCWSTR opt, float value) {
 	);
 }
 
-void Registry::remove(LPCWSTR opt) {
+void Registry::remove(const std::wstring &opt) {
 	RegDeleteValue(
 		m_reg_key,
-		opt
+		opt.c_str()
 	);
 }

--- a/config.cpp
+++ b/config.cpp
@@ -28,17 +28,29 @@ Registry::Registry()
 Config Registry::get_config() {
 	std::vector<std::pair<ConfigOption, float>> keys;
 
+	const std::wstring migrated_registry_name = L"MigratedRegistry";
+	bool migrated_registry = (bool) ((int) get(migrated_registry_name.c_str(), 0.0f));
+
 	for (int i = _CONFIG_OPTIONS_START + 1; i < _CONFIG_OPTIONS_END; i++) {
 		ConfigOption opt = (ConfigOption) i;
-		keys.push_back(std::make_pair(opt, get(opt, cfg_defaults.at(opt))));
+		if (migrated_registry) {
+			keys.push_back(std::make_pair(opt, get(config_names.at(opt).c_str(), cfg_defaults.at(opt))));
+		} else {
+			std::pair<ConfigOption, float> key = std::make_pair(opt, get(std::to_wstring(opt).c_str(), cfg_defaults.at(opt)));
+			write(config_names.at(opt).c_str(), key.second);
+			remove(std::to_wstring(opt).c_str());
+			keys.push_back(key);
+		}
+	}
+
+	if (!migrated_registry) {
+		write(migrated_registry_name.c_str(), 1.0f);
 	}
 
 	return Config(keys.begin(), keys.end());
 }
 
-float Registry::get(ConfigOption opt, float default_) {
-	std::wstring option_name = std::to_wstring(opt);
-
+float Registry::get(LPCWSTR opt, float default_) {
 	wchar_t result[1 << 6] {};
 	DWORD result_type;
 	DWORD result_size = 1 << 6;
@@ -46,7 +58,7 @@ float Registry::get(ConfigOption opt, float default_) {
 	LSTATUS status = RegGetValue(
 		m_reg_key,
 		NULL,
-		std::to_wstring(opt).c_str(),
+		opt,
 		RRF_RT_REG_SZ,
 		&result_type,
 		result,
@@ -60,13 +72,20 @@ float Registry::get(ConfigOption opt, float default_) {
 	return std::stof(result);
 }
 
-void Registry::write(ConfigOption opt, float value) {
+void Registry::write(LPCWSTR opt, float value) {
 	RegSetValueEx(
 		m_reg_key,
-		std::to_wstring(opt).c_str(),
+		opt,
 		0,
 		REG_SZ,
 		(BYTE *) std::to_wstring(value).c_str(),
 		(std::to_wstring(value).size() + 1) * 2
+	);
+}
+
+void Registry::remove(LPCWSTR opt) {
+	RegDeleteValue(
+		m_reg_key,
+		opt
 	);
 }

--- a/config.h
+++ b/config.h
@@ -46,9 +46,9 @@ public:
 	Registry();
 
 	Config get_config();
-	float get(LPCWSTR opt, float default_);
-	void write(LPCWSTR opt, float value);
-	void remove(LPCWSTR opt);
+	float get(const std::wstring &opt, float default_);
+	void write(const std::wstring &opt, float value);
+	void remove(const std::wstring &opt);
 
 private:
 	HKEY m_reg_key;

--- a/config.h
+++ b/config.h
@@ -23,6 +23,22 @@ enum ConfigOption {
 	_CONFIG_OPTIONS_END
 };
 
+const static std::map<int, std::wstring> config_names = {
+	{ YonkStepSize, L"YonkStepSize" },
+	{ YonkHomeDrift, L"YonkHomeDrift" },
+	{ YonkEmotionScale, L"YonkEmotionScale" },
+	{ TimeDivisor, L"TimeDivisor" },
+	{ MaxColors, L"MaxColors" },
+	{ SpriteCount, L"SpriteCount" },
+	{ SpriteSize, L"SpriteSize" },
+	{ YonkShakeFactor, L"YonkShakeFactor" },
+	{ YonkPattern, L"YonkPattern" },
+	{ PatternChangeInterval, L"PatternChangeInterval" },
+	{ IsPatternFixed, L"IsPatternFixed" },
+	{ ImpostorChance, L"ImpostorChance" },
+	{ YonkPalette, L"YonkPalette" },
+};
+
 using Config = std::map<ConfigOption, float>;
 
 class Registry {
@@ -30,8 +46,9 @@ public:
 	Registry();
 
 	Config get_config();
-	float get(ConfigOption opt, float default_);
-	void write(ConfigOption opt, float value);
+	float get(LPCWSTR opt, float default_);
+	void write(LPCWSTR opt, float value);
+	void remove(LPCWSTR opt);
 
 private:
 	HKEY m_reg_key;
@@ -52,4 +69,5 @@ const static Config cfg_defaults = {
 	{ ImpostorChance, (float)pow(0.002f, 1.0f/3.0f) },	// i'm sorry
 	{ YonkPalette, 0.0f }
 };
+
 const static Config cfg = Registry().get_config();

--- a/configdialog.cpp
+++ b/configdialog.cpp
@@ -30,7 +30,7 @@ void ConfigDialog::save() {
 	Registry registry;
 
 	for (const auto &entry : m_current_config) {
-		registry.write(config_names.at(entry.first).c_str(), entry.second);
+		registry.write(config_names.at(entry.first), entry.second);
 	}
 }
 

--- a/configdialog.cpp
+++ b/configdialog.cpp
@@ -30,7 +30,7 @@ void ConfigDialog::save() {
 	Registry registry;
 
 	for (const auto &entry : m_current_config) {
-		registry.write(entry.first, entry.second);
+		registry.write(config_names.at(entry.first).c_str(), entry.second);
 	}
 }
 

--- a/configdialog.h
+++ b/configdialog.h
@@ -74,4 +74,5 @@ const static std::map<PaletteGroup, std::wstring> palette_strings = {
 	{ PaletteGroup::All, L"All" },
 	{ PaletteGroup::Canon, L"Canon" },
 	{ PaletteGroup::NonCanon, L"Non-Canon" },
+	{ PaletteGroup::RandomlyGenerated, L"I'm Feeling Lucky" },
 };

--- a/graphics.cpp
+++ b/graphics.cpp
@@ -1,17 +1,10 @@
 #include "graphics.h"
 #include "resources.h"
 
-// Here, textures are born not by loading from disk...
-Palette::Palette(const std::initializer_list<Color> &i_list) {
-	std::copy(i_list.begin(), i_list.end(), begin());
-}
-
-// But by our own hands, with ingredients.
 Bitmap::Bitmap(const std::initializer_list<GLubyte> &i_list) {
 	std::copy(i_list.begin(), i_list.end(), begin());
 }
 
-// Lazily baked, not wasting our time...
 const Texture *Texture::get(const Palette &palette, const Bitmap &bitmap) {
 	auto ids = std::make_pair(palette.id(), bitmap.id());
 	auto result = texture_cache.find(ids);
@@ -23,7 +16,6 @@ const Texture *Texture::get(const Palette &palette, const Bitmap &bitmap) {
 	return texture_cache.at(ids);
 }
 
-// And make calling convenient, 'fore I wish any crimes.
 const Texture *Texture::of(PaletteName palette_name, BitmapName bitmap_name) {
 	return get(PALETTES.at(palette_name), *load_bitmap(bitmap_name));
 }

--- a/graphics.cpp
+++ b/graphics.cpp
@@ -20,6 +20,10 @@ const Texture *Texture::of(PaletteName palette_name, BitmapName bitmap_name) {
 	return get(PALETTES.at(palette_name), *load_bitmap(bitmap_name));
 }
 
+const Texture *Texture::of(const Palette *palette, BitmapName bitmap_name) {
+	return get(*palette, *load_bitmap(bitmap_name));
+}
+
 Bitmap::Bitmap(const GLubyte *data) {
 	std::copy(data, data + size(), begin());
 }

--- a/graphics.h
+++ b/graphics.h
@@ -9,51 +9,12 @@
 #include <string>
 
 #include "context.h"
+#include "palettes.h"
+#include "common.h"
 
-enum class PaletteName;
 enum BitmapName;
 
 constexpr static unsigned int BITMAP_WH = 128;
-
-using Color = std::tuple<BYTE, BYTE, BYTE, BYTE>;
-enum Channel {
-	RED = 0,
-	GREEN = 1,
-	BLUE = 2,
-	ALPHA = 3
-};
-
-using Id = unsigned int;
-static Id running_id = 0;
-
-class Empty {};
-template <typename Base> class Identifiable : public Base {
-public:
-	Identifiable() : m_id(running_id++) {}
-
-	Id id() const {
-		return m_id;
-	}
-
-private:
-	const Id m_id;
-};
-
-enum PaletteIndex {
-	PI_TRANSPARENT = 0,      
-	PI_SCALES = 1,          
-	PI_SCALES_HIGHLIGHT = 2,  
-	PI_SCALES_SHADOW = 3,     
-	PI_HORNS = 4,
-	PI_EYE = 5,
-	PI_WHITES = 6,
-	PI_HORNS_SHADOW = 7,
-	_PALETTE_SIZE
-};
-class Palette : public Identifiable<std::array<Color, _PALETTE_SIZE>> {
-public:
-	Palette(const std::initializer_list<Color> &i_list);
-};
 
 class Bitmap : public Identifiable<std::array<GLubyte, BITMAP_WH * BITMAP_WH>> {
 public:

--- a/graphics.h
+++ b/graphics.h
@@ -26,6 +26,7 @@ class Texture {
 public:
 	static const Texture *get(const Palette &palette, const Bitmap &bitmap);
 	static const Texture *of(PaletteName palette_name, BitmapName bitmap_name);
+	static const Texture *of(const Palette *palette, BitmapName bitmap_name);
 
 	const Palette &palette() const;
 

--- a/palettes.cpp
+++ b/palettes.cpp
@@ -1,5 +1,6 @@
 #include <map>
 #include <algorithm>
+#include <vector>
 
 #include "palettes.h"
 #include "common.h"
@@ -31,7 +32,7 @@ Palette *RandomPalettes::new_random_palette() {
 
 	colors[PI_SCALES] = random_color();
 	colors[PI_HORNS] = random_color();
-	colors[PI_EYE] = random_color();
+	colors[PI_EYE] = darken_color(random_color());
 	colors[PI_WHITES] = { 240, 240, 240, 255 };
 
 	colors[PI_SCALES_HIGHLIGHT] = lighten_color(colors[PI_SCALES]);

--- a/palettes.cpp
+++ b/palettes.cpp
@@ -158,12 +158,20 @@ Color RandomPalettes::recolorize(const Color &color, float red_weight, float gre
 }
 
 std::set<RandomPalettes::GenerationTraits> RandomPalettes::random_traits() {
+	auto random_inverse_falloff_percent = [](float scale) -> float {
+		if (rand() % 50 == 0) {
+			return 1.0f; // Very ocassionally, a trait will have 100% chance
+		}
+
+		return 1.0f / ((rand() % 500 / 100.0f) + 0.25f) * scale;
+	};
+
 	const static std::map<GenerationTraits, float> trait_chances = {
-		{ GenerationTraits::ColorfulHorns, 0.5f },
-		{ GenerationTraits::SwapHornsAndScales, 0.1f },
-		{ GenerationTraits::BlackEyes, 0.05f },
-		{ GenerationTraits::PastelScales, 0.2f },
-		{ GenerationTraits::CrystalBody, 0.1f },
+		{ GenerationTraits::ColorfulHorns, random_inverse_falloff_percent(1.0f) },
+		{ GenerationTraits::SwapHornsAndScales, random_inverse_falloff_percent(0.4f) },
+		{ GenerationTraits::BlackEyes, random_inverse_falloff_percent(0.2f) },
+		{ GenerationTraits::PastelScales, random_inverse_falloff_percent(0.3f) },
+		{ GenerationTraits::CrystalBody, random_inverse_falloff_percent(0.2f) },
 	};
 
 	std::set<GenerationTraits> traits;

--- a/palettes.cpp
+++ b/palettes.cpp
@@ -1,0 +1,21 @@
+#include "palettes.h"
+
+Palette::Palette(const std::initializer_list<Color> &i_list) {
+	std::copy(i_list.begin(), i_list.end(), begin());
+}
+
+const Palette &Palette::random(int rng_token) {
+	static std::map<int, Palette *> generated_palettes;
+
+	auto result = generated_palettes.find(rng_token);
+
+	if (result == generated_palettes.end()) {
+		generated_palettes[rng_token] = new_random_palette();
+	}
+
+	return *generated_palettes.at(rng_token);
+}
+
+Palette *Palette::new_random_palette() {
+	
+}

--- a/palettes.cpp
+++ b/palettes.cpp
@@ -29,7 +29,7 @@ const Palette *RandomPalettes::random(int rng_token) {
 }
 
 Palette *RandomPalettes::new_random_palette() {
-	static int bias_intensity = (int) (1.0f / (cfg.at(MaxColors) / config_ranges.at(MaxColors).second) * 3.0f);
+	static int bias_intensity = (int) (30.0f / ((cfg.at(MaxColors) + 14.0f) / config_ranges.at(MaxColors).second));
 
 	static float red_bias = rand() % bias_intensity * (rand() % 2 ? -1.0f : 1.0f);
 	static float green_bias = rand() % bias_intensity * (rand() % 2 ? -1.0f : 1.0f);
@@ -163,7 +163,7 @@ std::set<RandomPalettes::GenerationTraits> RandomPalettes::random_traits() {
 			return 1.0f; // Very ocassionally, a trait will have 100% chance
 		}
 
-		return 1.0f / ((rand() % 500 / 100.0f) + 0.25f) * scale;
+		return 1.0f / ((rand() % 300 / 100.0f + 2) + 0.25f) * scale;
 	};
 
 	const static std::map<GenerationTraits, float> trait_chances = {

--- a/palettes.cpp
+++ b/palettes.cpp
@@ -1,10 +1,18 @@
+#include <map>
+#include <algorithm>
+
 #include "palettes.h"
+#include "common.h"
+
+Palette::Palette(const std::array<Color, _PALETTE_SIZE> &colors) {
+	std::copy(colors.begin(), colors.end(), begin());
+}
 
 Palette::Palette(const std::initializer_list<Color> &i_list) {
 	std::copy(i_list.begin(), i_list.end(), begin());
 }
 
-const Palette &Palette::random(int rng_token) {
+const Palette &RandomPalettes::random(int rng_token) {
 	static std::map<int, Palette *> generated_palettes;
 
 	auto result = generated_palettes.find(rng_token);
@@ -16,6 +24,50 @@ const Palette &Palette::random(int rng_token) {
 	return *generated_palettes.at(rng_token);
 }
 
-Palette *Palette::new_random_palette() {
-	
+Palette *RandomPalettes::new_random_palette() {
+	std::array<Color, _PALETTE_SIZE> colors;
+
+	colors[PI_TRANSPARENT] = { 0, 0, 0, 0 };
+
+	colors[PI_SCALES] = random_color();
+	colors[PI_HORNS] = random_color();
+	colors[PI_EYE] = random_color();
+	colors[PI_WHITES] = { 240, 240, 240, 255 };
+
+	colors[PI_SCALES_HIGHLIGHT] = lighten_color(colors[PI_SCALES]);
+	colors[PI_SCALES_SHADOW] = darken_color(colors[PI_SCALES]);
+
+	colors[PI_HORNS_SHADOW] = darken_color(colors[PI_HORNS]);
+
+	return new Palette(colors);
+}
+
+Color RandomPalettes::random_color() {
+	return { rand() % 255, rand() % 255, rand() % 255, 255 };
+}
+
+Color RandomPalettes::darken_color(const Color &color) {
+	int new_red = std::get<RED>(color) / 2;
+	int new_green = std::get<GREEN>(color) / 2;
+	int new_blue = std::get<BLUE>(color) / 1.5; 
+
+	return {
+		std::clamp(new_red, 0, 255),
+		std::clamp(new_green, 0, 255),
+		std::clamp(new_blue, 0, 255),
+		255,
+	};
+}
+
+Color RandomPalettes::lighten_color(const Color &color) {
+	int new_red = std::get<RED>(color) + 50;
+	int new_green = std::get<GREEN>(color) + 50;
+	int new_blue = std::get<BLUE>(color) + 50; 
+
+	return {
+		std::clamp(new_red, 0, 255),
+		std::clamp(new_green, 0, 255),
+		std::clamp(new_blue, 0, 255),
+		255,
+	};
 }

--- a/palettes.cpp
+++ b/palettes.cpp
@@ -12,7 +12,7 @@ Palette::Palette(const std::initializer_list<Color> &i_list) {
 	std::copy(i_list.begin(), i_list.end(), begin());
 }
 
-const Palette &RandomPalettes::random(int rng_token) {
+const Palette *RandomPalettes::random(int rng_token) {
 	static std::map<int, Palette *> generated_palettes;
 
 	auto result = generated_palettes.find(rng_token);
@@ -21,7 +21,7 @@ const Palette &RandomPalettes::random(int rng_token) {
 		generated_palettes[rng_token] = new_random_palette();
 	}
 
-	return *generated_palettes.at(rng_token);
+	return generated_palettes.at(rng_token);
 }
 
 Palette *RandomPalettes::new_random_palette() {

--- a/palettes.cpp
+++ b/palettes.cpp
@@ -28,23 +28,80 @@ const Palette *RandomPalettes::random(int rng_token) {
 Palette *RandomPalettes::new_random_palette() {
 	std::array<Color, _PALETTE_SIZE> colors;
 
-	colors[PI_TRANSPARENT] = { 0, 0, 0, 0 };
+	static float red_weight = rand() % 100 / 200.0f + 0.6f;
+	static float green_weight = rand() % 100 / 200.0f + 0.35f;
+	static float blue_weight = rand() % 100 / 200.0f + 0.5f;
 
-	colors[PI_SCALES] = random_color();
-	colors[PI_HORNS] = random_color();
-	colors[PI_EYE] = darken_color(random_color());
+	colors[PI_SCALES] = random_color(600, red_weight, green_weight, blue_weight);
+	colors[PI_HORNS] = random_gray();
+	colors[PI_EYE] = random_color(200, red_weight, green_weight, blue_weight);
 	colors[PI_WHITES] = { 240, 240, 240, 255 };
+
+	for (auto &color : colors) {
+		color = noisify(color, 15.0f);
+	}
+
+	auto traits = random_traits();
+
+	if (traits.find(GenerationTraits::ColorfulHorns) != traits.end()) {
+		colors[PI_HORNS] = random_color(500, red_weight, green_weight, blue_weight);
+	}
+
+	if (traits.find(GenerationTraits::SwapHornsAndScales) != traits.end()) {
+		std::swap(colors[PI_HORNS], colors[PI_SCALES]);
+	}
+
+	if (traits.find(GenerationTraits::BlackEyes) != traits.end()) {
+		colors[PI_WHITES] = random_color(50, red_weight, green_weight, blue_weight);
+		colors[PI_EYE] = random_color(700, red_weight, green_weight, blue_weight);
+	}
 
 	colors[PI_SCALES_HIGHLIGHT] = lighten_color(colors[PI_SCALES]);
 	colors[PI_SCALES_SHADOW] = darken_color(colors[PI_SCALES]);
 
 	colors[PI_HORNS_SHADOW] = darken_color(colors[PI_HORNS]);
 
+	colors[PI_TRANSPARENT] = { 0, 0, 0, 0 };
+
 	return new Palette(colors);
 }
 
-Color RandomPalettes::random_color() {
-	return { rand() % 255, rand() % 255, rand() % 255, 255 };
+Color RandomPalettes::random_color(int budget, float red_weight, float green_weight, float blue_weight) {
+	int max_budget = 4.0f / 5.0f * budget;
+
+	int red = 0;
+	int green = 0;
+	int blue = 0;
+
+	while (budget > 0) {
+		int budget_chunk = budget < 30 ? budget : 30;
+
+		int channel = rand() % 3;
+
+		if (channel == RED && red >= max_budget) continue;
+		if (channel == GREEN && green >= max_budget) continue;
+		if (channel == BLUE && blue >= max_budget) continue;
+
+		switch (channel) {
+			case RED: red += budget_chunk * red_weight; break;
+			case GREEN: green += budget_chunk * green_weight; break; 
+			case BLUE: blue += budget_chunk * blue_weight; break; 
+		}
+
+		budget -= budget_chunk;
+	}
+
+	return {
+		std::clamp(red, 0, 255),
+		std::clamp(green, 0, 255),
+		std::clamp(blue, 0, 255),
+		255,
+	};
+}
+
+Color RandomPalettes::random_gray() {
+	int luminance = rand() % 255;
+	return { luminance, luminance, luminance, 255 };
 }
 
 Color RandomPalettes::darken_color(const Color &color) {
@@ -71,4 +128,35 @@ Color RandomPalettes::lighten_color(const Color &color) {
 		std::clamp(new_blue, 0, 255),
 		255,
 	};
+}
+
+Color RandomPalettes::noisify(const Color &color, float degree) {
+	int new_red = std::get<RED>(color) + (((rand() % 100) / 100) * degree);
+	int new_green = std::get<GREEN>(color) + (((rand() % 100) / 100) * degree);
+	int new_blue = std::get<BLUE>(color) + (((rand() % 100) / 100) * degree);
+
+	return {
+		std::clamp(new_red, 0, 255),
+		std::clamp(new_green, 0, 255),
+		std::clamp(new_blue, 0, 255),
+		255,
+	};
+}
+
+std::set<RandomPalettes::GenerationTraits> RandomPalettes::random_traits() {
+	const static std::map<GenerationTraits, float> trait_chances = {
+		{ GenerationTraits::ColorfulHorns, 0.5f },
+		{ GenerationTraits::SwapHornsAndScales, 0.1f },
+		{ GenerationTraits::BlackEyes, 0.05f },
+	};
+
+	std::set<GenerationTraits> traits;
+
+	for (const auto &pair : trait_chances) {
+		if (rand() % 100 / 100.0f < pair.second) {
+			traits.insert(pair.first);
+		}
+	}
+	
+	return traits;
 }

--- a/palettes.cpp
+++ b/palettes.cpp
@@ -167,7 +167,7 @@ std::set<RandomPalettes::GenerationTraits> RandomPalettes::random_traits() {
 	};
 
 	const static std::map<GenerationTraits, float> trait_chances = {
-		{ GenerationTraits::ColorfulHorns, random_inverse_falloff_percent(1.0f) },
+		{ GenerationTraits::ColorfulHorns, random_inverse_falloff_percent(0.7f) },
 		{ GenerationTraits::SwapHornsAndScales, random_inverse_falloff_percent(0.4f) },
 		{ GenerationTraits::BlackEyes, random_inverse_falloff_percent(0.2f) },
 		{ GenerationTraits::PastelScales, random_inverse_falloff_percent(0.3f) },

--- a/palettes.cpp
+++ b/palettes.cpp
@@ -46,17 +46,22 @@ Palette *RandomPalettes::new_random_palette() {
 		color = recolorize(color, red_bias, green_bias, blue_bias);
 	}
 
+	colors[PI_WHITES] = { 240, 240, 240, 255 };
+
 	auto traits = random_traits();
 
 	if (traits.find(GenerationTraits::ColorfulHorns) != traits.end()) {
 		colors[PI_HORNS] = random_color();
 	}
 
+	if (traits.find(GenerationTraits::PastelScales) != traits.end()) {
+		colors[PI_SCALES] = lighten_color(lighten_color(colors[PI_SCALES]));
+		colors[PI_WHITES] = { 255, 255, 255, 255 };
+	}
+
 	if (traits.find(GenerationTraits::SwapHornsAndScales) != traits.end()) {
 		std::swap(colors[PI_HORNS], colors[PI_SCALES]);
 	}
-
-	colors[PI_WHITES] = { 240, 240, 240, 255 };
 
 	if (traits.find(GenerationTraits::BlackEyes) != traits.end()) {
 		colors[PI_WHITES] = { 0, 0, 0, 255 };
@@ -65,8 +70,13 @@ Palette *RandomPalettes::new_random_palette() {
 
 	colors[PI_SCALES_HIGHLIGHT] = lighten_color(colors[PI_SCALES]);
 	colors[PI_SCALES_SHADOW] = darken_color(colors[PI_SCALES]);
-
 	colors[PI_HORNS_SHADOW] = darken_color(colors[PI_HORNS]);
+
+	if (traits.find(GenerationTraits::CrystalBody) != traits.end()) {
+		colors[PI_SCALES_HIGHLIGHT] = darken_color(colors[PI_SCALES]);
+		colors[PI_SCALES_SHADOW] = lighten_color(colors[PI_SCALES]);
+		colors[PI_HORNS_SHADOW] = lighten_color(colors[PI_HORNS]);
+	}
 
 	colors[PI_TRANSPARENT] = { 0, 0, 0, 0 };
 
@@ -152,6 +162,8 @@ std::set<RandomPalettes::GenerationTraits> RandomPalettes::random_traits() {
 		{ GenerationTraits::ColorfulHorns, 0.5f },
 		{ GenerationTraits::SwapHornsAndScales, 0.1f },
 		{ GenerationTraits::BlackEyes, 0.05f },
+		{ GenerationTraits::PastelScales, 0.2f },
+		{ GenerationTraits::CrystalBody, 0.1f },
 	};
 
 	std::set<GenerationTraits> traits;

--- a/palettes.h
+++ b/palettes.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <set>
 #include <initializer_list>
 
 #include "common.h"
@@ -29,9 +30,18 @@ public:
 	static const Palette *random(int rng_token);
 
 private:
+	enum class GenerationTraits {
+		ColorfulHorns,
+		SwapHornsAndScales,
+		BlackEyes,
+	};
+
 	static Palette *new_random_palette();
-	static Color random_color();
+	static Color random_color(int budget, float red_weight, float green_weight, float blue_weight);
+	static Color random_gray();
 	static Color darken_color(const Color &color);
 	static Color lighten_color(const Color &color);
+	static Color noisify(const Color &color, float degree = 1.0f);
+	static std::set<GenerationTraits> random_traits();
 };
 

--- a/palettes.h
+++ b/palettes.h
@@ -33,5 +33,5 @@ private:
 	static Color random_color();
 	static Color darken_color(const Color &color);
 	static Color lighten_color(const Color &color);
-}
+};
 

--- a/palettes.h
+++ b/palettes.h
@@ -20,11 +20,16 @@ enum PaletteIndex {
 };
 class Palette : public Identifiable<std::array<Color, _PALETTE_SIZE>> {
 public:
+	Palette(const std::array<Color, _PALETTE_SIZE> &colors);
 	Palette(const std::initializer_list<Color> &i_list);
-
-	static const Palette &random(int rng_token);
-
-private:
-	static Palette *new_random_palette();
 };
+
+namespace RandomPalettes {
+	const Palette &random(int rng_token);
+
+	Palette *new_random_palette();
+	Color random_color();
+	Color darken_color(const Color &color);
+	Color lighten_color(const Color &color);
+}
 

--- a/palettes.h
+++ b/palettes.h
@@ -37,11 +37,12 @@ private:
 	};
 
 	static Palette *new_random_palette();
-	static Color random_color(int budget, float red_weight, float green_weight, float blue_weight);
+	static Color random_color();
 	static Color random_gray();
 	static Color darken_color(const Color &color);
 	static Color lighten_color(const Color &color);
 	static Color noisify(const Color &color, float degree = 1.0f);
+	static Color recolorize(const Color &color, float red_weight, float green_weight, float blue_weight);
 	static std::set<GenerationTraits> random_traits();
 };
 

--- a/palettes.h
+++ b/palettes.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <array>
+#include <initializer_list>
+
+#include "common.h"
+
+enum class PaletteName;
+
+enum PaletteIndex {
+	PI_TRANSPARENT = 0,      
+	PI_SCALES = 1,          
+	PI_SCALES_HIGHLIGHT = 2,  
+	PI_SCALES_SHADOW = 3,     
+	PI_HORNS = 4,
+	PI_EYE = 5,
+	PI_WHITES = 6,
+	PI_HORNS_SHADOW = 7,
+	_PALETTE_SIZE
+};
+class Palette : public Identifiable<std::array<Color, _PALETTE_SIZE>> {
+public:
+	Palette(const std::initializer_list<Color> &i_list);
+
+	static const Palette &random(int rng_token);
+
+private:
+	static Palette *new_random_palette();
+};
+

--- a/palettes.h
+++ b/palettes.h
@@ -34,6 +34,8 @@ private:
 		ColorfulHorns,
 		SwapHornsAndScales,
 		BlackEyes,
+		PastelScales,
+		CrystalBody,
 	};
 
 	static Palette *new_random_palette();

--- a/palettes.h
+++ b/palettes.h
@@ -24,12 +24,14 @@ public:
 	Palette(const std::initializer_list<Color> &i_list);
 };
 
-namespace RandomPalettes {
-	const Palette &random(int rng_token);
+class RandomPalettes {
+public:
+	static const Palette *random(int rng_token);
 
-	Palette *new_random_palette();
-	Color random_color();
-	Color darken_color(const Color &color);
-	Color lighten_color(const Color &color);
+private:
+	static Palette *new_random_palette();
+	static Color random_color();
+	static Color darken_color(const Color &color);
+	static Color lighten_color(const Color &color);
 }
 

--- a/sprite.cpp
+++ b/sprite.cpp
@@ -147,7 +147,7 @@ std::array<float, Yonker::_EMOTIONS_COUNT> Yonker::emotion_vector(Context &ctx) 
 // That's no Llokin! That's something sinistrous!
 // The temper of character just misses the mark...
 // Emergency meeting! That's awfully suspicious!
-Impostor::Impostor(PaletteName palette, const Point &home)
+Impostor::Impostor(const Palette *palette, const Point &home)
 	: Sprite(Texture::of(palette, random_bitmap()), home) { }
 
 BitmapName Impostor::random_bitmap() {

--- a/sprite.cpp
+++ b/sprite.cpp
@@ -1,7 +1,10 @@
+#include <algorithm>
+
 #include "sprite.h"
 #include "noise.h"
 #include "resources.h"
 #include "config.h"
+#include "common.h"
 
 using std::get;
 
@@ -97,12 +100,8 @@ void Yonker::update(Context &ctx) {
 }
 
 const Bitmap &Yonker::bitmap_for_current_emotion(Context &ctx) const {
-	auto clamp = [](int n, int min, int max) -> int {
-		return n < min ? min : (n > max) ? max : n;
-	};
-
-	auto emotion_map_index_of = [clamp](float emotion) -> int {
-		return clamp(round(emotion * cfg.at(YonkEmotionScale)), -1, 1) + 1;
+	auto emotion_map_index_of = [](float emotion) -> int {
+		return std::clamp((int) round(emotion * cfg.at(YonkEmotionScale)), -1, 1) + 1;
 	};
 
 	int empathetic = emotion_map_index_of(m_emotion_vector[EMPATHY]);

--- a/sprite.h
+++ b/sprite.h
@@ -60,7 +60,7 @@ protected:
 
 class Impostor : public Sprite {
 public:
-	Impostor(PaletteName palette, const Point &home);
+	Impostor(const Palette *palette, const Point &home);
 
 protected:
 	static BitmapName random_bitmap();

--- a/spritecontrol.h
+++ b/spritecontrol.h
@@ -27,6 +27,7 @@ enum class PaletteGroup {
 	All,
 	Canon,
 	NonCanon,
+	RandomlyGenerated,
 	_PALETTE_OPTION_COUNT
 };
 

--- a/spritecontrol.h
+++ b/spritecontrol.h
@@ -39,9 +39,9 @@ public:
 
 private:
 	const Texture *next_texture() const;
-	PaletteName next_palette() const;
+	const Palette *next_palette() const;
 
-	std::vector<PaletteName> m_palettes;
+	std::vector<const Palette *> m_palettes;
 };
 
 class PatternPlayer {

--- a/yokscr.vcxproj
+++ b/yokscr.vcxproj
@@ -150,11 +150,13 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="common.h" />
     <ClInclude Include="config.h" />
     <ClInclude Include="configdialog.h" />
     <ClInclude Include="context.h" />
     <ClInclude Include="graphics.h" />
     <ClInclude Include="noise.h" />
+    <ClInclude Include="palettes.h" />
     <ClInclude Include="resources.h" />
     <ClInclude Include="resourcew.h" />
     <ClInclude Include="scene.h" />
@@ -168,6 +170,7 @@
     <ClCompile Include="context.cpp" />
     <ClCompile Include="graphics.cpp" />
     <ClCompile Include="noise.cpp" />
+    <ClCompile Include="palettes.cpp" />
     <ClCompile Include="scene.cpp" />
     <ClCompile Include="resources.cpp" />
     <ClCompile Include="sprite.cpp" />


### PR DESCRIPTION
As I recently discovered, trying to manually adjust the config options from the registry is really difficult when all you have to go off of are numbers. So this PR should fix that.

They are now named the same way as in code. (Because that's the simplest.)

At the current moment, any "old" registry values should be automatically migrated when the screensaver runs for the first time.