### PR TITLE
Fix unintended side effects when increasing bravery

### DIFF
--- a/sprite.cpp
+++ b/sprite.cpp
@@ -8,7 +8,7 @@
 
 using std::get;
 
-Sprite::Sprite(const Texture *texture, const Point &home) 
+Sprite::Sprite(const Texture *texture, const Point &home)
 	: m_texture(texture), m_home(home), m_relpos(0.0f, 0.0f), m_size(cfg.at(SpriteSize) / 1000.0f) { }
 
 void Sprite::change_texture(const Texture *texture) {
@@ -75,25 +75,27 @@ void Yonker::update(Context &ctx) {
 		return a + abs(b);
 	};
 
-	float emotion_magnitude = 
+	float emotion_magnitude =
 		std::accumulate(m_emotion_vector.begin(), m_emotion_vector.end(), 0.0f, abs_plus);
 
 	// In little steps up and down they'll roam,
 	// But never too far outside their home.
-	get<X>(m_relpos) = Noise::wiggle(
-		get<X>(m_relpos),
-		-cfg.at(YonkHomeDrift),
-		cfg.at(YonkHomeDrift),
-		cfg.at(YonkStepSize) * (emotion_magnitude * cfg.at(YonkShakeFactor))
-	);
+	if (cfg.at(YonkHomeDrift) < 0.000001f) {
+		get<X>(m_relpos) = Noise::wiggle(
+			get<X>(m_relpos),
+			-cfg.at(YonkHomeDrift),
+			cfg.at(YonkHomeDrift),
+			cfg.at(YonkStepSize) * (emotion_magnitude * cfg.at(YonkShakeFactor)) / max((cfg.at(YonkHomeDrift) / cfg_defaults.at(YonkHomeDrift)), 1)
+		);
 
-	get<Y>(m_relpos) = Noise::wiggle(
-		get<Y>(m_relpos),
-		-cfg.at(YonkHomeDrift),
-		cfg.at(YonkHomeDrift),
-		cfg.at(YonkStepSize) * (emotion_magnitude * cfg.at(YonkShakeFactor))
-	);
-	
+		get<Y>(m_relpos) = Noise::wiggle(
+			get<Y>(m_relpos),
+			-cfg.at(YonkHomeDrift),
+			cfg.at(YonkHomeDrift),
+			cfg.at(YonkStepSize) * (emotion_magnitude * cfg.at(YonkShakeFactor)) / max((cfg.at(YonkHomeDrift) / cfg_defaults.at(YonkHomeDrift)), 1)
+		);
+	}
+
 	Sprite::update(ctx);
 
 	change_texture(Texture::get(m_texture->palette(), bitmap_for_current_emotion(ctx)));
@@ -113,17 +115,17 @@ const Bitmap &Yonker::bitmap_for_current_emotion(Context &ctx) const {
 		// Go down _within_ layers, and the heart optimistic,
 		// Go off towards the right, and the head energetic.
 		// The center is calm; the corners, eclectic!
-		{   
+		{
 			{ lksix,          lkhusk,     lkhusk },
 			{ lkunamused, lkunamused,      lksix },
-			{ lkxd,             lkxd,      lksix }, 
+			{ lkxd,             lkxd,      lksix },
 		},
-		{  
+		{
 			{ lkunamused, lkunamused,         lk },
-			{  lkconcern,         lk,         lk }, 
-			{  lkconcern, lkthumbsup, lkthumbsup }, 
+			{  lkconcern,         lk,         lk },
+			{  lkconcern, lkthumbsup, lkthumbsup },
 		},
-		{   
+		{
 			{ lkexhausted, lkexhausted, lkexhausted },
 			{     lkthink,     lkthink,       lkjoy },
 			{       lkjoy,      lkcool,       lksix },
@@ -148,15 +150,16 @@ std::array<float, Yonker::_EMOTIONS_COUNT> Yonker::emotion_vector(Context &ctx) 
 // The temper of character just misses the mark...
 // Emergency meeting! That's awfully suspicious!
 Impostor::Impostor(const Palette *palette, const Point &home)
-	: Sprite(Texture::of(palette, random_bitmap()), home) { }
+	: Sprite(Texture::of(palette, random_bitmap()), home) {
+}
 
 BitmapName Impostor::random_bitmap() {
 	static std::vector<BitmapName> impostors = { cvjoy, nx, vx, lkmoyai, fn, fnplead };
 	static std::vector<BitmapName> yoy = { lkyoy, lkyoyapprove, fnyoy, cvyoy };
 
 	if (Noise::random() < 0.5f) {
-		return impostors[(int)(Noise::random() * impostors.size())];
+		return impostors[(int) (Noise::random() * impostors.size())];
 	} else {
-		return yoy[(int)(Noise::random() * yoy.size())];
+		return yoy[(int) (Noise::random() * yoy.size())];
 	}
 }

--- a/sprite.cpp
+++ b/sprite.cpp
@@ -80,7 +80,7 @@ void Yonker::update(Context &ctx) {
 
 	// In little steps up and down they'll roam,
 	// But never too far outside their home.
-	if (cfg.at(YonkHomeDrift) < 0.000001f) {
+	if (cfg.at(YonkHomeDrift) >= 0.000001f) {
 		get<X>(m_relpos) = Noise::wiggle(
 			get<X>(m_relpos),
 			-cfg.at(YonkHomeDrift),
@@ -150,8 +150,7 @@ std::array<float, Yonker::_EMOTIONS_COUNT> Yonker::emotion_vector(Context &ctx) 
 // The temper of character just misses the mark...
 // Emergency meeting! That's awfully suspicious!
 Impostor::Impostor(const Palette *palette, const Point &home)
-	: Sprite(Texture::of(palette, random_bitmap()), home) {
-}
+	: Sprite(Texture::of(palette, random_bitmap()), home) { }
 
 BitmapName Impostor::random_bitmap() {
 	static std::vector<BitmapName> impostors = { cvjoy, nx, vx, lkmoyai, fn, fnplead };

--- a/sprite.cpp
+++ b/sprite.cpp
@@ -42,18 +42,21 @@ void Sprite::draw(Context &ctx) {
 }
 
 void Sprite::update(Context &ctx) {
-	auto wrap = [](float n, float min, float max) -> float {
-		if (n < min) {
-			return max - (min - n);
-		} else if (n > max) {
-			return min + (n - max);
+	auto wrap = [](float home, float total, float min, float max) -> float {
+		if (total < min) {
+			return home + (max - min);
+		} else if (total > max) {
+			return home + (min - max);
 		} else {
-			return n;
+			return home;
 		}
 	};
 
-	get<X>(m_home) = wrap(get<X>(m_home), -1.0f - cfg.at(YonkHomeDrift), 1.0f + cfg.at(YonkHomeDrift));
-	get<Y>(m_home) = wrap(get<Y>(m_home), -1.0f - cfg.at(YonkHomeDrift), 1.0f + cfg.at(YonkHomeDrift));
+	float edge_boundary = 0.15f + m_size / 1.1f;
+	float horizontal_correction = max((float) ctx.rect().right / (float) ctx.rect().bottom, 1.0f);
+	float vertical_correction = max((float) ctx.rect().bottom / (float) ctx.rect().right, 1.0f);
+	get<X>(m_home) = wrap(get<X>(m_home), final<X>(), -1.0f - (edge_boundary / horizontal_correction), 1.0f + (edge_boundary / horizontal_correction));
+	get<Y>(m_home) = wrap(get<Y>(m_home), final<Y>(), -1.0f - (edge_boundary / vertical_correction), 1.0f + (edge_boundary / vertical_correction));
 }
 
 Point &Sprite::home() {


### PR DESCRIPTION
This makes the yokers not shake violently when increasing just the bravery setting (without increasing the shakiness). They will also not disappear for far too long when going off-screen at high bravery.