### PR TITLE
Destroy all warnings

### DIFF
--- a/common.h
+++ b/common.h
@@ -23,3 +23,7 @@ enum Channel {
 	BLUE = 2,
 	ALPHA = 3
 };
+
+template <typename To, typename From> To cast(From value) {
+	return static_cast<To>(value);
+}

--- a/config.cpp
+++ b/config.cpp
@@ -4,6 +4,7 @@
 #include <utility>
 
 #include "config.h"
+#include "common.h"
 
 Config::Config() 
 	: m_store(Cfg::All.size())
@@ -13,11 +14,11 @@ Config::Config()
 	}
 }
 
-float &Config::operator[](const Cfg::Definition &opt) {
+double &Config::operator[](const Cfg::Definition &opt) {
 	return m_store[opt.index];
 }
 
-float Config::operator[](const Cfg::Definition &opt) const {
+double Config::operator[](const Cfg::Definition &opt) const {
 	return m_store[opt.index];
 }
 
@@ -64,7 +65,7 @@ Config Registry::get_config() {
 	return config;
 }
 
-float Registry::get(const std::wstring &opt, float default_) {
+double Registry::get(const std::wstring &opt, double default_) {
 	wchar_t result[1 << 6] {};
 	DWORD result_type;
 	DWORD result_size = 1 << 6;
@@ -86,14 +87,17 @@ float Registry::get(const std::wstring &opt, float default_) {
 	return std::stof(result);
 }
 
-void Registry::write(const std::wstring &opt, float value) {
+void Registry::write(const std::wstring &opt, double value) {
+	auto string_value = std::to_wstring(value);
+	auto data_size = cast<DWORD>((string_value.size() + 1) * 2);
+
 	RegSetValueEx(
 		m_reg_key,
 		opt.c_str(),
 		0,
 		REG_SZ,
-		(BYTE *) std::to_wstring(value).c_str(),
-		(std::to_wstring(value).size() + 1) * 2
+		(BYTE *) string_value.c_str(),
+		data_size
 	);
 }
 

--- a/config.cpp
+++ b/config.cpp
@@ -46,7 +46,7 @@ Config Registry::get_config() {
 	Config config;
 
 	const std::wstring is_registry_migrated_name = L"IsRegistryMigrated";
-	bool is_registry_migrated = get(is_registry_migrated_name, 0.0f) != 0.0f;
+	bool is_registry_migrated = get(is_registry_migrated_name, 0.0) != 0.0;
 
 	for (const auto &opt : Cfg::All) {
 		if (is_registry_migrated) {
@@ -59,7 +59,7 @@ Config Registry::get_config() {
 	}
 
 	if (!is_registry_migrated) {
-		write(is_registry_migrated_name, 1.0f);
+		write(is_registry_migrated_name, 1.0);
 	}
 
 	return config;

--- a/config.h
+++ b/config.h
@@ -25,15 +25,15 @@ struct Cfg {
 		.index = __COUNTER__,
 		.name = L"YonkStepSize", 
 		.legacy_id = 1001,
-		.default_ = 0.005f, 
+		.default_ = 0.005, 
 	};
 
 	inline const static Definition HomeDrift = { 
 		.index = __COUNTER__,
 		.name = L"YonkHomeDrift", 
 		.legacy_id = 1002,
-		.default_= 0.3f, 
-		.range = { 0.0f, 5.0f },
+		.default_= 0.3, 
+		.range = { 0.0, 5.0 },
 		.dialog_control_id = IDC_YONK_HOME_DRIFT,
 	};
 
@@ -41,8 +41,8 @@ struct Cfg {
 		.index = __COUNTER__,
 		.name = L"YonkEmotionScale", 
 		.legacy_id = 1003,
-		.default_= 5.0f, 
-		.range = { 0.0f, 10.0f },
+		.default_= 5.0, 
+		.range = { 0.0, 10.0 },
 		.dialog_control_id = IDC_YONK_EMOTION_SCALE,
 	};
 
@@ -50,8 +50,8 @@ struct Cfg {
 		.index = __COUNTER__,
 		.name = L"TimeDivisor", 
 		.legacy_id = 1004,
-		.default_= 180.0f, 
-		.range = { 10.0f, 300.0f },
+		.default_= 180.0, 
+		.range = { 10.0, 300.0 },
 		.dialog_control_id = IDC_TIME_DIVISOR,
 	};
 
@@ -59,8 +59,8 @@ struct Cfg {
 		.index = __COUNTER__,
 		.name = L"MaxColors", 
 		.legacy_id = 1005,
-		.default_= 5.0f, 
-		.range = { 2.0f, 47.0f },
+		.default_= 5.0, 
+		.range = { 2.0, 47.0 },
 		.dialog_control_id = IDC_MAX_COLORS,
 	};
 
@@ -68,8 +68,8 @@ struct Cfg {
 		.index = __COUNTER__,
 		.name = L"SpriteCount",
 		.legacy_id = 1006,
-		.default_ = 80.0f,
-		.range = { 1.0f, 200.0f },
+		.default_ = 80.0,
+		.range = { 1.0, 200.0 },
 		.dialog_control_id = IDC_SPRITE_COUNT,
 	};
 
@@ -77,8 +77,8 @@ struct Cfg {
 		.index = __COUNTER__,
 		.name = L"SpriteSize",
 		.legacy_id = 1007,
-		.default_ = 50.0f,
-		.range = { 10.0f, 200.0f },
+		.default_ = 50.0,
+		.range = { 10.0, 200.0 },
 		.dialog_control_id = IDC_SPRITE_SIZE,
 	};
 
@@ -86,8 +86,8 @@ struct Cfg {
 		.index = __COUNTER__,
 		.name = L"YonkShakeFactor",
 		.legacy_id = 1008,
-		.default_ = 2.0f,
-		.range = { 0.0f, 5.0f },
+		.default_ = 2.0,
+		.range = { 0.0, 5.0 },
 		.dialog_control_id = IDC_YONK_SHAKE_FACTOR,
 	};
 
@@ -95,7 +95,7 @@ struct Cfg {
 		.index = __COUNTER__,
 		.name = L"YonkPattern",
 		.legacy_id = 1009,
-		.default_ = 0.0f,
+		.default_ = 0.0,
 		.dialog_control_id = IDC_YONK_PATTERN,
 	};
 
@@ -103,8 +103,8 @@ struct Cfg {
 		.index = __COUNTER__,
 		.name = L"PatternChangeInterval",
 		.legacy_id = 1010,
-		.default_ = 60.0f * 15.0f,
-		.range = { 30.0f, 60.0f * 30.0f },
+		.default_ = 60.0 * 15.0,
+		.range = { 30.0, 60.0 * 30.0 },
 		.dialog_control_id = IDC_PATTERN_CHANGE_INTERVAL,
 	};
 
@@ -112,7 +112,7 @@ struct Cfg {
 		.index = __COUNTER__,
 		.name = L"IsPatternFixed",
 		.legacy_id = 1011,
-		.default_ = 0.0f,
+		.default_ = 0.0,
 		.dialog_control_id = IDC_PATTERN_FIX,
 	};
 
@@ -120,8 +120,8 @@ struct Cfg {
 		.index = __COUNTER__,
 		.name = L"ImpostorChance",
 		.legacy_id = 1012,
-		.default_ = powf(0.002f, 1.0f / 3.0f),
-		.range = { 0.0f, 1.0f },
+		.default_ = pow(0.002, 1.0 / 3.0),
+		.range = { 0.0, 1.0 },
 		.dialog_control_id = IDC_IMPOSTOR_CHANCE,
 	};
 
@@ -129,7 +129,7 @@ struct Cfg {
 		.index = __COUNTER__,
 		.name = L"YonkPalette",
 		.legacy_id = 1013,
-		.default_ = 0.0f,
+		.default_ = 0.0,
 		.dialog_control_id = IDC_YONK_PALETTE,
 	};
 
@@ -137,23 +137,23 @@ struct Cfg {
 		.index = __COUNTER__,
 		.name = L"PlayOverDesktop",
 		.legacy_id = 1014,
-		.default_ = 0.0f,
+		.default_ = 0.0,
 		.dialog_control_id = IDC_PLAY_OVER_DESKTOP,
 	};
 
 	inline const static Definition TrailLength = {
 		.index = __COUNTER__,
 		.name = L"TrailLength",
-		.default_ = 3.0f,
-		.range = { 1.0f, 25.0f },
+		.default_ = 3.0,
+		.range = { 1.0, 25.0 },
 		.dialog_control_id = IDC_TRAIL_LENGTH,
 	};
 
 	inline const static Definition TrailSpace = {
 		.index = __COUNTER__,
 		.name = L"TrailSpace",
-		.default_ = 10.0f,
-		.range = { 1.0f, 50.0f },
+		.default_ = 10.0,
+		.range = { 1.0, 50.0 },
 		.dialog_control_id = IDC_TRAIL_SPACE,
 	};
 
@@ -161,13 +161,13 @@ struct Cfg {
 	inline const static Definition MaxTrailCount = {
 		.index = __COUNTER__,
 		.name = L"MaxTrailCount",
-		.default_ = 3000.0f,
+		.default_ = 3000.0,
 	};
 
 	inline const static Definition TrailsEnabled = {
 		.index = __COUNTER__,
 		.name = L"TrailsEnabled",
-		.default_ = 0.0f,
+		.default_ = 0.0,
 		.dialog_control_id = IDC_TRAILS_ENABLED,
 	};
 

--- a/config.h
+++ b/config.h
@@ -17,8 +17,8 @@ struct Cfg {
 		const size_t index;
 		const std::wstring name;
 		const int legacy_id;
-		const float default_;
-		const std::pair<float, float> range;
+		const double default_;
+		const std::pair<double, double> range;
 		const int dialog_control_id;
 	};
 
@@ -164,11 +164,11 @@ class Config {
 public:
 	Config();
 
-	float &operator[](const Cfg::Definition &opt);
-	float operator[](const Cfg::Definition &opt) const;
+	double &operator[](const Cfg::Definition &opt);
+	double operator[](const Cfg::Definition &opt) const;
 
 private:
-	std::vector<float> m_store;
+	std::vector<double> m_store;
 };
 
 class Registry {
@@ -176,8 +176,8 @@ public:
 	Registry();
 
 	Config get_config();
-	float get(const std::wstring &opt, float default_);
-	void write(const std::wstring &opt, float value);
+	double get(const std::wstring &opt, double default_);
+	void write(const std::wstring &opt, double value);
 	void remove(const std::wstring &opt);
 
 private:

--- a/configdialog.cpp
+++ b/configdialog.cpp
@@ -106,10 +106,10 @@ BOOL ConfigDialog::combobox_changed(HWND combobox, int option_type) {
 
 	switch (option_type) {
 		case IDC_YONK_PATTERN:
-			m_current_config[Cfg::Pattern] = (float) reverse_lookup(pattern_strings, option_name);
+			m_current_config[Cfg::Pattern] = (double) reverse_lookup(pattern_strings, option_name);
 			break;
 		case IDC_YONK_PALETTE:
-			m_current_config[Cfg::Palette] = (float) reverse_lookup(palette_strings, option_name);
+			m_current_config[Cfg::Palette] = (double) reverse_lookup(palette_strings, option_name);
 			break;
 	}
 
@@ -118,7 +118,7 @@ BOOL ConfigDialog::combobox_changed(HWND combobox, int option_type) {
 
 BOOL ConfigDialog::checkbox_checked(WPARAM wparam, HWND checkbox, const Cfg::Definition &option) {
 	bool checked = Button_GetCheck(checkbox) == BST_CHECKED;
-	m_current_config[option] = checked ? 1.0f : 0.0f;
+	m_current_config[option] = checked ? 1.0 : 0.0;
 	refresh();
 	return FALSE;
 }
@@ -126,11 +126,11 @@ BOOL ConfigDialog::checkbox_checked(WPARAM wparam, HWND checkbox, const Cfg::Def
 // Continuous sliders use integers only...
 // What Redmond designer responds to this folly?!
 long long ConfigDialog::encodef(double value) {
-	return cast<long long>(value * 8.0f);
+	return cast<long long>(value * 8.0);
 }
 
 double ConfigDialog::decodef(long long value) {
-	return value / 8.0f;
+	return value / 8.0;
 }
 
 void ConfigDialog::refresh() {
@@ -168,17 +168,17 @@ void ConfigDialog::refresh() {
 		(PaletteGroup) m_current_config[Cfg::Palette]).c_str()
 	);
 
-	bool is_pattern_fixed = m_current_config[Cfg::IsPatternFixed] == 1.0f;
+	bool is_pattern_fixed = m_current_config[Cfg::IsPatternFixed] == 1.0;
 	HWND pattern_interval_slider = GetDlgItem(m_dialog, IDC_PATTERN_CHANGE_INTERVAL);
 	HWND pattern_fixed_check = GetDlgItem(m_dialog, IDC_PATTERN_FIX);
 	Button_SetCheck(pattern_fixed_check, is_pattern_fixed);
 	EnableWindow(pattern_interval_slider, !is_pattern_fixed);
 
-	bool is_playing_over_desktop = m_current_config[Cfg::PlayOverDesktop] == 1.0f;
+	bool is_playing_over_desktop = m_current_config[Cfg::PlayOverDesktop] == 1.0;
 	HWND play_over_desktop_check = GetDlgItem(m_dialog, IDC_PLAY_OVER_DESKTOP);
 	Button_SetCheck(play_over_desktop_check, is_playing_over_desktop);
 
-	bool are_trails_enabled = m_current_config[Cfg::TrailsEnabled] == 1.0f;
+	bool are_trails_enabled = m_current_config[Cfg::TrailsEnabled] == 1.0;
 	HWND trail_length_slider = GetDlgItem(m_dialog, IDC_TRAIL_LENGTH);
 	HWND trail_space_slider = GetDlgItem(m_dialog, IDC_TRAIL_SPACE);
 	HWND trails_enabled_check = GetDlgItem(m_dialog, IDC_TRAILS_ENABLED);

--- a/configdialog.cpp
+++ b/configdialog.cpp
@@ -82,7 +82,7 @@ BOOL ConfigDialog::command(WPARAM wparam, LPARAM lparam) {
 }
 
 BOOL ConfigDialog::slider_changed(WPARAM wparam, HWND slider) {
-	int value = SendMessage(slider, TBM_GETPOS, 0, 0);
+	auto value = SendMessage(slider, TBM_GETPOS, 0, 0);
 
 	auto opt = *std::find_if(Cfg::All.begin(), Cfg::All.end(), [&](const auto &opt) {
 		return opt.dialog_control_id == GetDlgCtrlID(slider);
@@ -119,11 +119,11 @@ BOOL ConfigDialog::checkbox_checked(WPARAM wparam, HWND checkbox, const Cfg::Def
 
 // Continuous sliders use integers only...
 // What Redmond designer responds to this folly?!
-int ConfigDialog::encodef(float value) {
-	return (int) (value * 8.0f);
+long long ConfigDialog::encodef(double value) {
+	return cast<long long>(value * 8.0f);
 }
 
-float ConfigDialog::decodef(int value) {
+double ConfigDialog::decodef(long long value) {
 	return value / 8.0f;
 }
 

--- a/configdialog.h
+++ b/configdialog.h
@@ -17,8 +17,8 @@ public:
 	BOOL combobox_changed(HWND combobox, int option);
 	
 private:
-	int encodef(float value);
-	float decodef(int value);
+	long long encodef(double value);
+	double decodef(long long value);
 	void refresh();
 	
 	template <typename K, typename V> K reverse_lookup(const std::map<K, V> &map, V value) {

--- a/context.cpp
+++ b/context.cpp
@@ -54,6 +54,6 @@ unsigned int &Context::frame_count() {
 	return m_frame_count;
 }
 
-float Context::t() {
+double Context::t() {
 	return m_frame_count / cfg[Cfg::TimeDivisor];
 }

--- a/context.h
+++ b/context.h
@@ -19,7 +19,7 @@ public:
 	RECT rect();
 	unsigned int &frame_count();
 
-	float t();
+	double t();
 
 private:
 	HWND m_window;

--- a/graphics.h
+++ b/graphics.h
@@ -37,7 +37,7 @@ private:
 	const BitmapData &m_bitmap;
 };
 
-using Point = std::pair<GLfloat, GLfloat>;
+using Point = std::pair<GLdouble, GLdouble>;
 enum Coord {
 	X = 0,
 	Y = 1

--- a/noise.cpp
+++ b/noise.cpp
@@ -1,26 +1,27 @@
 #include "noise.h"
+#include "common.h"
 
-float PerlinNoise::get(float x, float y, float z) {
+double PerlinNoise::get(double x, double y, double z) {
 	Vector v = Vector(x, y, z);
 	return cell_interpolate(cell_dots(v), v);
 }
 
-PerlinNoise::Vector::Vector(float x, float y, float z) 
-	: std::tuple<float, float, float>(x, y, z) { }
+PerlinNoise::Vector::Vector(double x, double y, double z) 
+	: std::tuple<double, double, double>(x, y, z) { }
 
-float PerlinNoise::Vector::x() const {
+double PerlinNoise::Vector::x() const {
 	return std::get<0>(*this);
 }
 
-float PerlinNoise::Vector::y() const {
+double PerlinNoise::Vector::y() const {
 	return std::get<1>(*this);
 }
 
-float PerlinNoise::Vector::z() const {
+double PerlinNoise::Vector::z() const {
 	return std::get<2>(*this);
 }
 
-float PerlinNoise::Vector::dot(const Vector &v) const {
+double PerlinNoise::Vector::dot(const Vector &v) const {
 	return x() * v.x() + y() * v.y() + z() * v.z();
 }
 
@@ -28,22 +29,22 @@ PerlinNoise::Vector PerlinNoise::Vector::sub(const Vector &v) const {
 	return Vector(x() - v.x(), y() - v.y(), z() - v.z());
 };
 
-PerlinNoise::Vector PerlinNoise::grad_vector(int x, int y, int z) {
+PerlinNoise::Vector PerlinNoise::grad_vector(double x, double y, double z) {
 	// To grow a seed from a single point
 	// With orderly chaos a constant we anoint
 	// But be careful not to overflow
 	// For what happens then, well, no one knows
-	unsigned int seed = 1;
+	double seed = 1;
 	seed = 31 * seed + x;
 	seed = 31 * seed + y;
 	seed = 31 * seed + z;
 
-	std::srand(seed);
-	float f_x = (float) std::rand() / RAND_MAX;
-	float f_y = (float) std::rand() / RAND_MAX;
-	float f_z = (float) std::rand() / RAND_MAX;
+	std::srand(cast<unsigned int>(seed));
+	double f_x = (double) std::rand() / RAND_MAX;
+	double f_y = (double) std::rand() / RAND_MAX;
+	double f_z = (double) std::rand() / RAND_MAX;
 
-	float mag = sqrt(f_x * f_x + f_y * f_y + f_z * f_z);
+	double mag = sqrt(f_x * f_x + f_y * f_y + f_z * f_z);
 	f_x /= mag;
 	f_y /= mag;
 	f_z /= mag;
@@ -56,9 +57,9 @@ PerlinNoise::Vector PerlinNoise::grad_vector_from_corner(const Vector &v) {
 }
 
 std::array<PerlinNoise::Vector, 8> PerlinNoise::cell_corners(const Vector &v) {
-	int x = floor(v.x());
-	int y = floor(v.y());
-	int z = floor(v.z());
+	double x = floor(v.x());
+	double y = floor(v.y());
+	double z = floor(v.z());
 
 	return {
 		Vector(x, y, z),
@@ -87,7 +88,7 @@ std::array<PerlinNoise::Vector, 8> PerlinNoise::offset_vectors(const Vector &v) 
 	};
 }
 
-std::array<float, 8> PerlinNoise::cell_dots(const Vector &v) {
+std::array<double, 8> PerlinNoise::cell_dots(const Vector &v) {
 	auto offsets = offset_vectors(v);
 	auto corners = cell_corners(v);
 
@@ -103,27 +104,27 @@ std::array<float, 8> PerlinNoise::cell_dots(const Vector &v) {
 	};
 }
 
-float PerlinNoise::cell_interpolate(std::array<float, 8> dots, const Vector &v) {
-	float w_x = v.x() - floor(v.x());
-	float w_y = v.y() - floor(v.y());
-	float w_z = v.z() - floor(v.z());
+double PerlinNoise::cell_interpolate(std::array<double, 8> dots, const Vector &v) {
+	double w_x = v.x() - floor(v.x());
+	double w_y = v.y() - floor(v.y());
+	double w_z = v.z() - floor(v.z());
 
-	float bottom_i1 = interpolate(dots[0], dots[1], w_x);
-	float bottom_i2 = interpolate(dots[2], dots[4], w_x);
-	float bottom_i = interpolate(bottom_i1, bottom_i2, w_y);
+	double bottom_i1 = interpolate(dots[0], dots[1], w_x);
+	double bottom_i2 = interpolate(dots[2], dots[4], w_x);
+	double bottom_i = interpolate(bottom_i1, bottom_i2, w_y);
 
-	float top_i1 = interpolate(dots[3], dots[5], w_x);
-	float top_i2 = interpolate(dots[6], dots[7], w_x);
-	float top_i = interpolate(top_i1, top_i2, w_y);
+	double top_i1 = interpolate(dots[3], dots[5], w_x);
+	double top_i2 = interpolate(dots[6], dots[7], w_x);
+	double top_i = interpolate(top_i1, top_i2, w_y);
 
 	return interpolate(bottom_i, top_i, w_z);
 }
 
-float PerlinNoise::interpolate(float a, float b, float w) {
+double PerlinNoise::interpolate(double a, double b, double w) {
 	return (b - a) * (3.0 - w * 2.0) * w * w + a;
 }
 
-float Noise::wiggle(float base, float min, float max, float step) {
+double Noise::wiggle(double base, double min, double max, double step) {
 	bool up = random() < 0.5f;
 
 	if (up) {
@@ -133,7 +134,7 @@ float Noise::wiggle(float base, float min, float max, float step) {
 	}
 }
 
-float Noise::random() {
+double Noise::random() {
 	static std::random_device device;
 	static std::mt19937 rng(device());
 	static std::uniform_real_distribution<> dist(0.0f, 1.0f);

--- a/noise.cpp
+++ b/noise.cpp
@@ -63,13 +63,13 @@ std::array<PerlinNoise::Vector, 8> PerlinNoise::cell_corners(const Vector &v) {
 
 	return {
 		Vector(x, y, z),
-		Vector(x + 1.0f, y, z),
-		Vector(x, y + 1.0f, z),
-		Vector(x, y, z + 1.0f),
-		Vector(x + 1.0f, y + 1.0f, z),
-		Vector(x + 1.0f, y, z + 1.0f),
-		Vector(x, y + 1.0f, z + 1.0f),
-		Vector(x + 1.0f, y + 1.0f, z + 1.0f)
+		Vector(x + 1.0, y, z),
+		Vector(x, y + 1.0, z),
+		Vector(x, y, z + 1.0),
+		Vector(x + 1.0, y + 1.0, z),
+		Vector(x + 1.0, y, z + 1.0),
+		Vector(x, y + 1.0, z + 1.0),
+		Vector(x + 1.0, y + 1.0, z + 1.0)
 	};
 }
 
@@ -125,7 +125,7 @@ double PerlinNoise::interpolate(double a, double b, double w) {
 }
 
 double Noise::wiggle(double base, double min, double max, double step) {
-	bool up = random() < 0.5f;
+	bool up = random() < 0.5;
 
 	if (up) {
 		return base + random() * (max - base) * step;
@@ -137,7 +137,7 @@ double Noise::wiggle(double base, double min, double max, double step) {
 double Noise::random() {
 	static std::random_device device;
 	static std::mt19937 rng(device());
-	static std::uniform_real_distribution<> dist(0.0f, 1.0f);
+	static std::uniform_real_distribution<> dist(0.0, 1.0);
 
 	return dist(rng);
 }

--- a/noise.h
+++ b/noise.h
@@ -10,32 +10,32 @@
 // So may the world be empty, no beauty, no fun.
 class PerlinNoise {
 public:
-	static float get(float x, float y, float z);
+	static double get(double x, double y, double z);
 
 private:
-	class Vector : public std::tuple<float, float, float> {
+	class Vector : public std::tuple<double, double, double> {
 	public:
-		Vector(float x, float y, float z);
+		Vector(double x, double y, double z);
 
-		float x() const;
-		float y() const;
-		float z() const;
-		float dot(const Vector &v) const;
+		double x() const;
+		double y() const;
+		double z() const;
+		double dot(const Vector &v) const;
 		Vector sub(const Vector &v) const; // Overload? Well, if one would...
 		                                   // One will only choose what they think that they should
 	};
 
-	static Vector grad_vector(int x, int y, int z);
+	static Vector grad_vector(double x, double y, double z);
 	static Vector grad_vector_from_corner(const Vector &v);
 	static std::array<Vector, 8> cell_corners(const Vector &v);
 	static std::array<Vector, 8> offset_vectors(const Vector &v);
-	static std::array<float, 8> cell_dots(const Vector &v);
-	static float cell_interpolate(std::array<float, 8> dots, const Vector &v);
-	static float interpolate(float a, float b, float w);
+	static std::array<double, 8> cell_dots(const Vector &v);
+	static double cell_interpolate(std::array<double, 8> dots, const Vector &v);
+	static double interpolate(double a, double b, double w);
 };
 
 class Noise {
 public:
-	static float wiggle(float base, float min, float max, float step);
-	static float random();
+	static double wiggle(double base, double min, double max, double step);
+	static double random();
 };

--- a/palettes.cpp
+++ b/palettes.cpp
@@ -43,11 +43,11 @@ const PaletteData *RandomPalettes::random(int rng_token) {
 }
 
 PaletteData *RandomPalettes::new_random_palette() {
-	static int bias_intensity = (int) (20.0f / ((cfg[Cfg::MaxColors] + 4.0f) / Cfg::MaxColors.range.second));
+	static int bias_intensity = (int) (20.0 / ((cfg[Cfg::MaxColors] + 4.0) / Cfg::MaxColors.range.second));
 
-	static float red_bias = rand() % bias_intensity * (rand() % 2 ? -1.0f : 1.0f);
-	static float green_bias = rand() % bias_intensity * (rand() % 2 ? -1.0f : 1.0f);
-	static float blue_bias = rand() % bias_intensity * (rand() % 2 ? -1.0f : 1.0f);
+	static double red_bias = rand() % bias_intensity * (rand() % 2 ? -1.0 : 1.0);
+	static double green_bias = rand() % bias_intensity * (rand() % 2 ? -1.0 : 1.0);
+	static double blue_bias = rand() % bias_intensity * (rand() % 2 ? -1.0 : 1.0);
 
 	std::array<Color, _PALETTE_SIZE> colors;
 
@@ -120,14 +120,14 @@ Color RandomPalettes::random_gray() {
 }
 
 Color RandomPalettes::darken_color(const Color &color) {
-	int new_red = std::get<RED>(color) / 2;
-	int new_green = std::get<GREEN>(color) / 2;
-	int new_blue = std::get<BLUE>(color) / 1.5; 
+	double new_red = std::get<RED>(color) / 2;
+	double new_green = std::get<GREEN>(color) / 2;
+	double new_blue = std::get<BLUE>(color) / 1.5; 
 
 	return {
-		std::clamp(new_red, 0, 255),
-		std::clamp(new_green, 0, 255),
-		std::clamp(new_blue, 0, 255),
+		std::clamp(cast<int>(new_red), 0, 255),
+		std::clamp(cast<int>(new_green), 0, 255),
+		std::clamp(cast<int>(new_blue), 0, 255),
 		255,
 	};
 }
@@ -145,47 +145,47 @@ Color RandomPalettes::lighten_color(const Color &color) {
 	};
 }
 
-Color RandomPalettes::noisify(const Color &color, float degree) {
-	int new_red = std::get<RED>(color) + (((rand() % 100) / 100.0f) * degree);
-	int new_green = std::get<GREEN>(color) + (((rand() % 100) / 100.0f) * degree);
-	int new_blue = std::get<BLUE>(color) + (((rand() % 100) / 100.0f) * degree);
+Color RandomPalettes::noisify(const Color &color, double degree) {
+	double new_red = std::get<RED>(color) + (((rand() % 100) / 100.0) * degree);
+	double new_green = std::get<GREEN>(color) + (((rand() % 100) / 100.0) * degree);
+	double new_blue = std::get<BLUE>(color) + (((rand() % 100) / 100.0) * degree);
 
 	return {
-		std::clamp(new_red, 0, 255),
-		std::clamp(new_green, 0, 255),
-		std::clamp(new_blue, 0, 255),
+		std::clamp(cast<int>(new_red), 0, 255),
+		std::clamp(cast<int>(new_green), 0, 255),
+		std::clamp(cast<int>(new_blue), 0, 255),
 		255,
 	};
 }
 
-Color RandomPalettes::recolorize(const Color &color, float red_weight, float green_weight, float blue_weight) {
-	int new_red = std::get<RED>(color) + (rand() % 100 / 50.0f) * red_weight;
-	int new_green = std::get<GREEN>(color) + (rand() % 100 / 50.0f) * green_weight;
-	int new_blue = std::get<BLUE>(color) + (rand() % 100 / 50.0f) * blue_weight;
+Color RandomPalettes::recolorize(const Color &color, double red_weight, double green_weight, double blue_weight) {
+	double new_red = std::get<RED>(color) + (rand() % 100 / 50.0) * red_weight;
+	double new_green = std::get<GREEN>(color) + (rand() % 100 / 50.0) * green_weight;
+	double new_blue = std::get<BLUE>(color) + (rand() % 100 / 50.0) * blue_weight;
 
 	return {
-		std::clamp(new_red, 0, 255),
-		std::clamp(new_green, 0, 255),
-		std::clamp(new_blue, 0, 255),
+		std::clamp(cast<int>(new_red), 0, 255),
+		std::clamp(cast<int>(new_green), 0, 255),
+		std::clamp(cast<int>(new_blue), 0, 255),
 		255,
 	};
 }
 
 std::set<RandomPalettes::GenerationTraits> RandomPalettes::random_traits() {
-	auto random_inverse_falloff_percent = [](float scale) -> float {
+	auto random_inverse_falloff_percent = [](double scale) -> double {
 		if (rand() % 50 == 0) {
-			return 1.0f; // Very ocassionally, a trait will have 100% chance
+			return 1.0; // Very ocassionally, a trait will have 100% chance
 		}
 
-		return 1.0f / ((rand() % 300 / 100.0f + 2) + 0.25f) * scale;
+		return 1.0 / ((rand() % 300 / 100.0 + 2) + 0.25) * scale;
 	};
 
-	const static std::map<GenerationTraits, float> trait_chances = {
-		{ GenerationTraits::ColorfulHorns, random_inverse_falloff_percent(0.7f) },
-		{ GenerationTraits::SwapHornsAndScales, random_inverse_falloff_percent(0.4f) },
-		{ GenerationTraits::BlackEyes, random_inverse_falloff_percent(0.2f) },
-		{ GenerationTraits::PastelScales, random_inverse_falloff_percent(0.3f) },
-		{ GenerationTraits::CrystalBody, random_inverse_falloff_percent(0.2f) },
+	const static std::map<GenerationTraits, double> trait_chances = {
+		{ GenerationTraits::ColorfulHorns, random_inverse_falloff_percent(0.7) },
+		{ GenerationTraits::SwapHornsAndScales, random_inverse_falloff_percent(0.4) },
+		{ GenerationTraits::BlackEyes, random_inverse_falloff_percent(0.2) },
+		{ GenerationTraits::PastelScales, random_inverse_falloff_percent(0.3) },
+		{ GenerationTraits::CrystalBody, random_inverse_falloff_percent(0.2) },
 	};
 
 	std::set<GenerationTraits> traits;

--- a/palettes.cpp
+++ b/palettes.cpp
@@ -191,7 +191,7 @@ std::set<RandomPalettes::GenerationTraits> RandomPalettes::random_traits() {
 	std::set<GenerationTraits> traits;
 
 	for (const auto &pair : trait_chances) {
-		if (rand() % 100 / 100.0f < pair.second) {
+		if (rand() % 100 / 100.0 < pair.second) {
 			traits.insert(pair.first);
 		}
 	}

--- a/palettes.h
+++ b/palettes.h
@@ -4,6 +4,8 @@
 #include <set>
 #include <initializer_list>
 #include <vector>
+#include <string>
+#include <stdexcept>
 
 #include "common.h"
 
@@ -51,8 +53,8 @@ private:
 	static Color random_gray();
 	static Color darken_color(const Color &color);
 	static Color lighten_color(const Color &color);
-	static Color noisify(const Color &color, float degree = 1.0f);
-	static Color recolorize(const Color &color, float red_weight, float green_weight, float blue_weight);
+	static Color noisify(const Color &color, double degree = 1.0);
+	static Color recolorize(const Color &color, double red_weight, double green_weight, double blue_weight);
 	static std::set<GenerationTraits> random_traits();
 };
 
@@ -808,6 +810,7 @@ public:
 			case PaletteGroup::Canon: return Canon;
 			case PaletteGroup::NonCanon: return NonCanon;
 			case PaletteGroup::All: return All;
+			default: throw std::domain_error("PaletteGroup " + std::to_string((int) group) + " is not valid.");
 		}
 	}
 };

--- a/scene.cpp
+++ b/scene.cpp
@@ -7,7 +7,7 @@ Scene::Scene(HWND window)
 // It's of utmost importance the context comes first!
 // Else reality cursed, at the seams it will burst!!!
 	: m_ctx(window),
-	  m_sprites(SpriteGenerator().make(cfg[Cfg::SpriteCount])),
+	  m_sprites(SpriteGenerator().make(cast<unsigned int>(cfg[Cfg::SpriteCount]))),
 	  m_choreographer((PatternName) cfg[Cfg::Pattern], &m_sprites, &m_ctx) { }
 
 void Scene::draw() {

--- a/scene.cpp
+++ b/scene.cpp
@@ -15,7 +15,7 @@ void Scene::draw() {
 	gluPerspective(45, 1.0 * m_ctx.rect().right / m_ctx.rect().bottom, 1.0, 1000);
 	glMatrixMode(GL_MODELVIEW);
 	glLoadIdentity();
-	glClearColor(0.1, 0.1, 0.1, 1.0);
+	glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
 	if (cfg[Cfg::PlayOverDesktop]) {

--- a/scene.cpp
+++ b/scene.cpp
@@ -15,7 +15,7 @@ void Scene::draw() {
 	gluPerspective(45, 1.0 * m_ctx.rect().right / m_ctx.rect().bottom, 1.0, 1000);
 	glMatrixMode(GL_MODELVIEW);
 	glLoadIdentity();
-	glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
+	glClearColor(0.1, 0.1, 0.1, 1.0);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
 	if (cfg[Cfg::PlayOverDesktop]) {
@@ -56,10 +56,10 @@ void Scene::draw_background() {
 
 	glBegin(GL_QUADS);
 
-	glTexCoord2f(1.0f, 0.0f); glVertex2f(1.0f, -1.0f);
-	glTexCoord2f(1.0f, 1.0f); glVertex2f(1.0f, 1.0f);
-	glTexCoord2f(0.0f, 1.0f); glVertex2f(-1.0f, 1.0f);
-	glTexCoord2f(0.0f, 0.0f); glVertex2f(-1.0f, -1.0f);
+	glTexCoord2f(1.0, 0.0); glVertex2f(1.0, -1.0);
+	glTexCoord2f(1.0, 1.0); glVertex2f(1.0, 1.0);
+	glTexCoord2f(0.0, 1.0); glVertex2f(-1.0, 1.0);
+	glTexCoord2f(0.0, 0.0); glVertex2f(-1.0, -1.0);
 
 	glEnd();
 }

--- a/sprite.cpp
+++ b/sprite.cpp
@@ -19,7 +19,7 @@ void Sprite::draw(Context &ctx) {
 	update(ctx);
 	m_texture->apply();
 
-	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
+	glColor4d(1.0, 1.0, 1.0, 1.0);
 
 	glPushMatrix();
 	transform();
@@ -29,12 +29,12 @@ void Sprite::draw(Context &ctx) {
 	// But plastered on a rectangular screen.
 	// Here we adjust so the ratio's fair
 	// And our wandering Llokin are properly seen.
-	float squarifiy_offset = (float) (ctx.rect().right - ctx.rect().bottom) / ctx.rect().right;
+	double squarifiy_offset = (double) (ctx.rect().right - ctx.rect().bottom) / ctx.rect().right;
 
-	glTexCoord2f(1.0f, 0.0f); glVertex2f(1.0f - squarifiy_offset, -1.0f);
-	glTexCoord2f(1.0f, 1.0f); glVertex2f(1.0f - squarifiy_offset, 1.0f);
-	glTexCoord2f(0.0f, 1.0f); glVertex2f(-1.0f + squarifiy_offset, 1.0f);
-	glTexCoord2f(0.0f, 0.0f); glVertex2f(-1.0f + squarifiy_offset, -1.0f);
+	glTexCoord2d(1.0, 0.0); glVertex2d(1.0 - squarifiy_offset, -1.0);
+	glTexCoord2d(1.0, 1.0); glVertex2d(1.0 - squarifiy_offset, 1.0);
+	glTexCoord2d(0.0, 1.0); glVertex2d(-1.0 + squarifiy_offset, 1.0);
+	glTexCoord2d(0.0, 0.0); glVertex2d(-1.0 + squarifiy_offset, -1.0);
 
 	glEnd();
 	glPopMatrix();
@@ -42,7 +42,7 @@ void Sprite::draw(Context &ctx) {
 }
 
 void Sprite::update(Context &ctx) {
-	auto wrap = [](float home, float total, float min, float max) -> float {
+	auto wrap = [](double home, double total, double min, double max) -> double {
 		if (total < min) {
 			return home + (max - min);
 		} else if (total > max) {
@@ -52,9 +52,9 @@ void Sprite::update(Context &ctx) {
 		}
 	};
 
-	float edge_boundary = 0.15f + m_size / 1.1f;
-	float horizontal_correction = max((float) ctx.rect().right / (float) ctx.rect().bottom, 1.0f);
-	float vertical_correction = max((float) ctx.rect().bottom / (float) ctx.rect().right, 1.0f);
+	double edge_boundary = 0.15f + m_size / 1.1f;
+	double horizontal_correction = max((double) ctx.rect().right / (double) ctx.rect().bottom, 1.0f);
+	double vertical_correction = max((double) ctx.rect().bottom / (double) ctx.rect().right, 1.0f);
 	get<X>(m_home) = wrap(get<X>(m_home), final<X>(), -1.0f - (edge_boundary / horizontal_correction), 1.0f + (edge_boundary / horizontal_correction));
 	get<Y>(m_home) = wrap(get<Y>(m_home), final<Y>(), -1.0f - (edge_boundary / vertical_correction), 1.0f + (edge_boundary / vertical_correction));
 }
@@ -64,8 +64,8 @@ Point &Sprite::home() {
 }
 
 void Sprite::transform() {
-	glTranslatef(final<X>(), final<Y>(), 0.0f);
-	glScalef(m_size, m_size, 1.0f);
+	glTranslated(final<X>(), final<Y>(), 0.0f);
+	glScaled(m_size, m_size, 1.0f);
 }
 
 Yonker::Yonker(const Texture *texture, const Point &home) 
@@ -74,16 +74,16 @@ Yonker::Yonker(const Texture *texture, const Point &home)
 void Yonker::update(Context &ctx) {
 	m_emotion_vector = emotion_vector(ctx);
 
-	auto abs_plus = [](float a, float b) -> float {
+	auto abs_plus = [](double a, double b) -> double {
 		return a + abs(b);
 	};
 
-	float emotion_magnitude =
-		std::accumulate(m_emotion_vector.begin(), m_emotion_vector.end(), 0.0f, abs_plus);
+	double emotion_magnitude =
+		std::accumulate(m_emotion_vector.begin(), m_emotion_vector.end(), 0.0, abs_plus);
 
 	// In little steps up and down they'll roam,
 	// But never too far outside their home.
-	if (cfg[Cfg::HomeDrift] >= 0.000001f) {
+	if (cfg[Cfg::HomeDrift] >= 0.000001) {
 		get<X>(m_relpos) = Noise::wiggle(
 			get<X>(m_relpos),
 			-cfg[Cfg::HomeDrift],
@@ -105,7 +105,7 @@ void Yonker::update(Context &ctx) {
 }
 
 const BitmapData &Yonker::bitmap_for_current_emotion(Context &ctx) const {
-	auto emotion_map_index_of = [](float emotion) -> int {
+	auto emotion_map_index_of = [](double emotion) -> int {
 		return std::clamp((int) round(emotion * cfg[Cfg::EmotionScale]), -1, 1) + 1;
 	};
 
@@ -138,7 +138,7 @@ const BitmapData &Yonker::bitmap_for_current_emotion(Context &ctx) const {
 	return *emotion_map[empathetic][optimistic][ambitious].data;
 }
 
-std::array<float, Yonker::_EMOTIONS_COUNT> Yonker::emotion_vector(Context &ctx) const {
+std::array<double, Yonker::_EMOTIONS_COUNT> Yonker::emotion_vector(Context &ctx) const {
 	// Continous noise will be perfect for this;
 	// Nearby to those pissed will also be pissed.
 	return {
@@ -159,7 +159,7 @@ Bitmaps::Definition &Impostor::random_bitmap() {
 	static auto impostors = Bitmaps::bitmaps_of_group(BitmapGroup::Impostor);
 	static auto yoy = Bitmaps::bitmaps_of_group(BitmapGroup::YoyImpostor);
 
-	if (Noise::random() < 0.5f) {
+	if (Noise::random() < 0.5) {
 		return impostors[(int) (Noise::random() * impostors.size())];
 	} else {
 		return yoy[(int) (Noise::random() * yoy.size())];

--- a/sprite.cpp
+++ b/sprite.cpp
@@ -9,7 +9,7 @@
 using std::get;
 
 Sprite::Sprite(const Texture *texture, const Point &home, const bool has_trail)
-	: m_texture(texture), m_home(home), m_relpos(0.0f, 0.0f), m_size(cfg[Cfg::SpriteSize] / 1000.0f), m_trail_start_index(0)
+	: m_texture(texture), m_home(home), m_relpos(0.0, 0.0), m_size(cfg[Cfg::SpriteSize] / 1000.0f), m_trail_start_index(0)
 {
 	if (has_trail) {
 		for (int i = 0; i < TrailSprite::get_trail_length(); i++) {
@@ -59,11 +59,11 @@ void Sprite::update(Context &ctx) {
 		}
 	};
 
-	double edge_boundary = 0.15f + m_size / 1.1f;
-	double horizontal_correction = max((double) ctx.rect().right / (double) ctx.rect().bottom, 1.0f);
-	double vertical_correction = max((double) ctx.rect().bottom / (double) ctx.rect().right, 1.0f);
-	get<X>(m_home) = wrap(get<X>(m_home), final<X>(), -1.0f - (edge_boundary / horizontal_correction), 1.0f + (edge_boundary / horizontal_correction));
-	get<Y>(m_home) = wrap(get<Y>(m_home), final<Y>(), -1.0f - (edge_boundary / vertical_correction), 1.0f + (edge_boundary / vertical_correction));
+	double edge_boundary = 0.15 + m_size / 1.1;
+	double horizontal_correction = max((double) ctx.rect().right / (double) ctx.rect().bottom, 1.0);
+	double vertical_correction = max((double) ctx.rect().bottom / (double) ctx.rect().right, 1.0);
+	get<X>(m_home) = wrap(get<X>(m_home), final<X>(), -1.0 - (edge_boundary / horizontal_correction), 1.0 + (edge_boundary / horizontal_correction));
+	get<Y>(m_home) = wrap(get<Y>(m_home), final<Y>(), -1.0 - (edge_boundary / vertical_correction), 1.0 + (edge_boundary / vertical_correction));
 }
 
 Point &Sprite::home() {
@@ -71,8 +71,8 @@ Point &Sprite::home() {
 }
 
 void Sprite::transform() {
-	glTranslated(final<X>(), final<Y>(), 0.0f);
-	glScaled(m_size, m_size, 1.0f);
+	glTranslated(final<X>(), final<Y>(), 0.0);
+	glScaled(m_size, m_size, 1.0);
 }
 
 void Sprite::update_trail() {
@@ -100,7 +100,7 @@ void Sprite::draw_trail(Context &ctx) {
 }
 
 Yonker::Yonker(const Texture *texture, const Point &home) 
-	: Sprite(texture, home), m_emotion_vector({ 0.0f, 0.0f, 0.0f }) { }
+	: Sprite(texture, home), m_emotion_vector({ 0.0, 0.0, 0.0 }) { }
 
 void Yonker::update(Context &ctx) {
 	m_emotion_vector = emotion_vector(ctx);
@@ -213,7 +213,7 @@ void TrailSprite::update(Context &ctx) { }
 void TrailSprite::draw_trail(Context &ctx) { }
 
 int TrailSprite::get_trail_length() {
-	if (cfg[Cfg::TrailsEnabled] != 1.0f) {
+	if (cfg[Cfg::TrailsEnabled] != 1.0) {
 		return 0;
 	}
 

--- a/sprite.h
+++ b/sprite.h
@@ -22,7 +22,7 @@ public:
 	virtual void draw(Context &ctx);
 	virtual void update(Context &ctx);
 
-	template <int C> float final() const {
+	template <int C> double final() const {
 		return std::get<C>(m_home) + std::get<C>(m_relpos);
 	}
 
@@ -34,7 +34,7 @@ protected:
 	const Texture *m_texture;
 	Point m_relpos;
 	Point m_home;
-	GLfloat m_size;
+	GLdouble m_size;
 };
 
 class Yonker : public Sprite {
@@ -45,7 +45,7 @@ public:
 		AMBITION = 2,
 		_EMOTIONS_COUNT
 	};
-	using EmotionVector = std::array<float, _EMOTIONS_COUNT>;
+	using EmotionVector = std::array<double, _EMOTIONS_COUNT>;
 
 	Yonker(const Texture *texture, const Point &home);
 

--- a/spritecontrol.cpp
+++ b/spritecontrol.cpp
@@ -62,7 +62,7 @@ const PaletteData *SpriteGenerator::next_palette() const {
 	// You'd be kicked outta Vegas for logarithmic repeating.
 	while (true) {
 		for (auto palette : m_palettes) {
-			if (Noise::random() < 1.8f / cfg[Cfg::MaxColors]) {
+			if (Noise::random() < 1.8 / cfg[Cfg::MaxColors]) {
 				return palette;
 			}
 		}
@@ -116,7 +116,7 @@ PatternPlayer::PatternPlayer(Sprites *sprites, Context *ctx)
 	: m_pattern(Roamers), m_sprites(sprites), m_ctx(ctx) { }
 
 double PatternPlayer::hash(unsigned int n) {
-	return ((n * n * 562448657) % 4096) / 4096.0f;
+	return ((n * n * 562448657) % 4096) / 4096.0;
 }
 
 unsigned int PatternPlayer::m_hash_offset = 0;
@@ -161,7 +161,7 @@ std::map<PatternName, SinglePassPlayer::MoveFunction> SinglePassPlayer::move_fun
 	}},
 	{ Square, [](Sprite *sprite, Context *ctx, double offset) {
 		get<X>(sprite->home()) += offset < 0.5 ? ((1.0 - offset) / cfg[Cfg::TimeDivisor]) : 0.0;
-		get<Y>(sprite->home()) += offset < 0.5 ? 0.0f: (offset / cfg[Cfg::TimeDivisor]);
+		get<Y>(sprite->home()) += offset < 0.5 ? 0.0: (offset / cfg[Cfg::TimeDivisor]);
 	}},
 	{ Bouncy, [](Sprite *sprite, Context *ctx, double offset) {
 		static int NorthWest = 0b01;
@@ -184,7 +184,7 @@ std::map<PatternName, SinglePassPlayer::MoveFunction> SinglePassPlayer::move_fun
 			get<X>(sprite->home()) = signbit(get<X>(sprite->home())) ? -1.0 : 1.0;
 		}
 
-		if (get<Y>(sprite->home()) > 1.0f || get<Y>(sprite->home()) < -1.0) {
+		if (get<Y>(sprite->home()) > 1.0 || get<Y>(sprite->home()) < -1.0) {
 			directions[sprite->id()] ^= South;
 			get<Y>(sprite->home()) = signbit(get<Y>(sprite->home())) ? -1.0 : 1.0;
 		}
@@ -204,7 +204,7 @@ std::map<PatternName, SinglePassPlayer::MoveFunction> SinglePassPlayer::move_fun
 	}},
 	{ Rose, [](Sprite *sprite, Context *ctx, double offset) {
 		double t = ctx->t() - (offset * 0.03 * cfg[Cfg::SpriteCount]);
-		double r = 0.04f * cfg[Cfg::SpriteCount] * t;
+		double r = 0.04 * cfg[Cfg::SpriteCount] * t;
 
 		double target_x = sin(r) * cos(t) * 0.8;
 		double target_y = sin(r) * sin(t) * 0.8;

--- a/spritecontrol.h
+++ b/spritecontrol.h
@@ -7,7 +7,7 @@
 #include "graphics.h"
 #include "sprite.h"
 
-const static float M_PI = std::acos(-1);
+const static double M_PI = std::acos(-1);
 
 using Sprites = std::vector<Sprite *>;
 
@@ -46,7 +46,7 @@ public:
 protected:
 	PatternPlayer(Sprites *sprites, Context *ctx);
 
-	static float hash(unsigned int n);
+	static double hash(unsigned int n);
 
 	static unsigned int m_hash_offset;
 	PatternName m_pattern;
@@ -62,7 +62,7 @@ public:
 	std::set<PatternName> &compatible_patterns() override;
 
 protected:
-	using MoveFunction = std::function<void(Sprite *, Context *, float offset)>;
+	using MoveFunction = std::function<void(Sprite *, Context *, double offset)>;
 	static std::map<PatternName, MoveFunction> move_functions;
 };
 
@@ -74,7 +74,7 @@ public:
 	std::set<PatternName> &compatible_patterns() override;
 
 protected:
-	using MoveFunction = std::function<void(Sprites *, Context *, std::function<float(Id)>)>;
+	using MoveFunction = std::function<void(Sprites *, Context *, std::function<double(Id)>)>;
 	static std::map<PatternName, MoveFunction> move_functions;
 };
 

--- a/yokscr.vcxproj
+++ b/yokscr.vcxproj
@@ -85,6 +85,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetExt>.scr</TargetExt>
     <TargetName>yok</TargetName>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/yokscr.vcxproj
+++ b/yokscr.vcxproj
@@ -141,6 +141,7 @@
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
#10 

Shut up shut up shut up shut up.

As part of this work, since it made things easier, I also converted every float in our codebase to a double. Originally I thought we couldn't do this because OpenGL required floats, but I was simply incorrect, it can work with doubles just fine.

I have also set warnings to be treated as errors in Release mode, to help gently encourage us to not introduce any more.

We're on /W3 right now. There are higher warning levels, but we will probably stay at /W3. I have absolutely no intention of increasing us to the most pedantic warning settings because we would have hundreds and hundreds of them, and these loss of data warnings we're dealing with now are already pretty fucking pointless. It's a shame because I would love to get good warnings that can catch actual problems, but they will be buried by 1000 other warnings that might be "oh shit" in other codebases but are "tell someone who cares" in this one. Maybe we need to curate a warning list or something.